### PR TITLE
Remove a retry using Basic Auth when NTLM/Negotiate is not supported

### DIFF
--- a/negotiator.go
+++ b/negotiator.go
@@ -61,22 +61,6 @@ func (l Negotiator) RoundTrip(req *http.Request) (res *http.Response, err error)
 	}
 
 	resauth := authheader(res.Header.Get("Www-Authenticate"))
-	if !resauth.IsNegotiate() && !resauth.IsNTLM() {
-		// Unauthorized, Negotiate not requested, let's try with basic auth
-		req.Header.Set("Authorization", string(reqauth))
-		io.Copy(ioutil.Discard, res.Body)
-		res.Body.Close()
-		req.Body = ioutil.NopCloser(bytes.NewReader(body.Bytes()))
-
-		res, err = rt.RoundTrip(req)
-		if err != nil {
-			return nil, err
-		}
-		if res.StatusCode != http.StatusUnauthorized {
-			return res, err
-		}
-		resauth = authheader(res.Header.Get("Www-Authenticate"))
-	}
 
 	if resauth.IsNegotiate() || resauth.IsNTLM() {
 		// 401 with request:Basic and response:Negotiate


### PR DESCRIPTION
Problem:
----------
We do not wish to use basic auth as means of authentication. The current implementation will try to use Basic Auth if the windows machine does not support negotiate.

Solution:
----------
For our purposes we only require negotiate to be used as a means of authentication therefore when headers are returned to indicate that negotiate isn't supported(the absence of the header indicates that) we will fail rather than retrying using basic auth.

Testing:
----------
- Tested with the windows server configured to have negotiate on and we can auth with no issue.
- Tested with the windows server configured to have negotiate off and we get a 401 returned as expected.

N.B. I don't think this should make it into the library however I would say that if the server does not indicate that it supports basic auth basic auth should never be retried. It seems to be assumed.